### PR TITLE
Universal ODBC database backend (Firebird/SQLServer/Oracle) + build fixes

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -161,6 +161,27 @@ if needs_rebuild hbdb_real.o "$PROJDIR/source/backends/gtk3/gtk3_db_real.c"; the
    NEED_LINK=1
 fi
 
+# Detect distro-portable terminal libs (CI runs on stock Ubuntu, so these
+# fixes only surface on other distros — see issues #11 (gpm) and #5 (ncurses)).
+#
+# ncurses: Debian/Ubuntu ship libncurses.so.6 (no bare .so without -dev),
+# Arch/Manjaro ship libncurses.so / libncursesw.so. Pick whatever exists.
+LIBDIRS="/usr/lib /usr/lib64 /lib /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /usr/lib/arm-linux-gnueabihf"
+NCURSES_LIB="-lncurses"
+for cand in libncursesw.so libncurses.so libncursesw.so.6 libncurses.so.6 libncursesw.so.5 libncurses.so.5; do
+   for d in $LIBDIRS; do
+      if [ -e "$d/$cand" ]; then NCURSES_LIB="-l:$cand"; break 2; fi
+   done
+done
+
+# gpm: Harbour's libgttrm.a references gpm_fd on builds compiled with GPM
+# support; libgpm is absent on many desktops, so only add -lgpm if present.
+GPM_LIB=""
+for d in $LIBDIRS; do
+   if ls "$d"/libgpm.so* >/dev/null 2>&1; then GPM_LIB="-lgpm"; break; fi
+done
+echo "  Terminal libs: ncurses='$NCURSES_LIB' gpm='${GPM_LIB:-<none>}'"
+
 # Skip link if nothing changed
 if [ "$NEED_LINK" -eq 0 ] && [ -f "${PROG}" ]; then
    echo "[5/6] ${PROG} — up to date (nothing changed)"
@@ -181,11 +202,11 @@ gcc ${PROG}.o gtk3_core.o gtk3_inspector.o $EXTRA_OBJS -g -o ${PROG} \
    -lhbcommon -lhbvm -lhbrtl -lhbrdd -lhbmacro -lhblang -lhbcpage -lhbpp \
    -lhbcplr -lrddntx -lrddcdx -lrddfpt -lhbsix -lhbusrrdd -lhbct \
    -lhbsqlit3 -lsddsqlt3 -lrddsql \
-   -lgttrm -lhbdebug -lhbpcre \
+   -lgttrm -lhbdebug -lhbpcre $GPM_LIB \
    $(pkg-config --libs gtk+-3.0) \
    $WEBKIT_LIBS \
    -lm -lpthread -ldl -lrt -lsqlite3 \
-   -L/usr/lib/x86_64-linux-gnu -l:libncurses.so.6 \
+   $NCURSES_LIB \
    -Wl,--end-group
 
 # [6/6] Install to bin/

--- a/source/core/classes.prg
+++ b/source/core/classes.prg
@@ -27,6 +27,11 @@ EXTERNAL HBPGSQL_QUERY, HBPGSQL_FIELDS, HBPGSQL_ERROR
 EXTERNAL HBPGSQL_LASTID, HBPGSQL_TABLES
 #endif
 
+// Database base class (TDatabase) + universal ODBC backend (TODBCDatabase).
+// TDatabase lives here now (defined once, early) so every DB subclass below
+// inherits it; the new ODBC engine fills the Firebird/SQLServer/Oracle stubs.
+#include "db_odbc.prg"
+
 //----------------------------------------------------------------------------//
 // TControl - Base class
 //----------------------------------------------------------------------------//
@@ -2154,68 +2159,8 @@ return hb_ValToStr( xVal )
 
 //----------------------------------------------------------------------------//
 // TDatabase - Abstract base class for all database connections
-//----------------------------------------------------------------------------//
-
-CLASS TDatabase
-
-   DATA cServer     INIT ""        // Host/server name
-   DATA nPort       INIT 0         // Port number
-   DATA cDatabase   INIT ""        // Database name or file path
-   DATA cUser       INIT ""        // Username
-   DATA cPassword   INIT ""        // Password
-   DATA cCharSet    INIT "UTF8"    // Character set
-   DATA lConnected  INIT .F.       // Connection status
-   DATA cLastError  INIT ""        // Last error message
-   DATA pHandle     INIT nil       // Native connection handle
-   DATA cDriver     INIT ""        // Driver name (for identification)
-
-   METHOD New() CONSTRUCTOR
-   METHOD Open()
-   METHOD Close()
-   METHOD Execute( cSQL )
-   METHOD Query( cSQL )
-   METHOD TableExists( cTable )
-   METHOD Tables()
-   METHOD LastError()
-   METHOD IsConnected()
-
-ENDCLASS
-
-METHOD New() CLASS TDatabase
-return Self
-
-METHOD Open() CLASS TDatabase
-   ::cLastError := "Abstract: override Open() in subclass"
-return .F.
-
-METHOD Close() CLASS TDatabase
-   ::lConnected := .F.
-   ::pHandle := nil
-return nil
-
-METHOD Execute( cSQL ) CLASS TDatabase
-   HB_SYMBOL_UNUSED( cSQL )
-   ::cLastError := "Abstract: override Execute() in subclass"
-return .F.
-
-METHOD Query( cSQL ) CLASS TDatabase
-   HB_SYMBOL_UNUSED( cSQL )
-   ::cLastError := "Abstract: override Query() in subclass"
-return {}
-
-METHOD TableExists( cTable ) CLASS TDatabase
-   HB_SYMBOL_UNUSED( cTable )
-return .F.
-
-METHOD Tables() CLASS TDatabase
-return {}
-
-METHOD LastError() CLASS TDatabase
-return ::cLastError
-
-METHOD IsConnected() CLASS TDatabase
-return ::lConnected
-
+//   Moved to source/core/db_odbc.prg (with the new TODBCDatabase backend),
+//   which is #included near the top of this file. See that file.
 //----------------------------------------------------------------------------//
 // TDBFTable - Native DBF/NTX/CDX table access via Harbour RDD
 //----------------------------------------------------------------------------//

--- a/source/core/classes.prg
+++ b/source/core/classes.prg
@@ -2921,58 +2921,10 @@ METHOD LastInsertId( cSeq ) CLASS TPostgreSQL
 return HBPGSQL_LASTID( ::pHandle, cSeq )
 
 //----------------------------------------------------------------------------//
-// TFirebird - Firebird connection (requires libfbclient)
+// TFirebird / TSQLServer / TOracle - now real ODBC-backed classes, defined in
+// db_odbc.prg as TODBCDatabase subclasses (included near the top of this file).
+// The former libfbclient/FreeTDS/OCI stubs were removed.
 //----------------------------------------------------------------------------//
-
-CLASS TFirebird INHERIT TDatabase
-   METHOD New() CONSTRUCTOR
-   METHOD Open()
-ENDCLASS
-
-METHOD New() CLASS TFirebird
-   ::cDriver := "Firebird"
-   ::nPort   := 3050
-return Self
-
-METHOD Open() CLASS TFirebird
-   ::cLastError := "Firebird support requires libfbclient. Install with: apt install firebird-dev"
-return .F.
-
-//----------------------------------------------------------------------------//
-// TSQLServer - SQL Server connection (requires FreeTDS/ODBC)
-//----------------------------------------------------------------------------//
-
-CLASS TSQLServer INHERIT TDatabase
-   METHOD New() CONSTRUCTOR
-   METHOD Open()
-ENDCLASS
-
-METHOD New() CLASS TSQLServer
-   ::cDriver := "SQLServer"
-   ::nPort   := 1433
-return Self
-
-METHOD Open() CLASS TSQLServer
-   ::cLastError := "SQL Server support requires FreeTDS. Install with: apt install freetds-dev"
-return .F.
-
-//----------------------------------------------------------------------------//
-// TOracle - Oracle connection (requires OCI)
-//----------------------------------------------------------------------------//
-
-CLASS TOracle INHERIT TDatabase
-   METHOD New() CONSTRUCTOR
-   METHOD Open()
-ENDCLASS
-
-METHOD New() CLASS TOracle
-   ::cDriver := "Oracle"
-   ::nPort   := 1521
-return Self
-
-METHOD Open() CLASS TOracle
-   ::cLastError := "Oracle support requires Oracle Instant Client"
-return .F.
 
 //----------------------------------------------------------------------------//
 // TMongoDB - MongoDB connection (requires mongoc driver)

--- a/source/core/db_odbc.prg
+++ b/source/core/db_odbc.prg
@@ -1,0 +1,290 @@
+// db_odbc.prg - database base class + universal ODBC backend.
+// #included by classes.prg; also compiles standalone (UI-free) for the smoke.
+//
+// TODBCDatabase fills the former Firebird/SQLServer/Oracle stubs through one
+// ODBC path (Harbour's hbodbc low-level SQL* API). Named TODBCDatabase (NOT
+// TODBC) because hbodbc.lib already exports HB_FUN_TODBC.
+
+#include "hbclass.ch"   // idempotent (guarded); needed when compiled standalone
+
+// --- ODBC constants (sql.ch is not on the portable include path) ---
+#define SQL_SUCCESS             0
+#define SQL_SUCCESS_WITH_INFO   1
+#define SQL_NO_DATA             100
+#define SQL_DRIVER_NOPROMPT     0
+#define SQL_FREESTMT_CLOSE      0
+#define SQL_FREESTMT_DROP       1
+#define SQL_C_CHAR              1
+#define SQL_C_DOUBLE            8
+
+//----------------------------------------------------------------------------//
+// TDatabase - Abstract base class for all database connections
+//----------------------------------------------------------------------------//
+
+CLASS TDatabase
+
+   DATA cServer     INIT ""        // Host/server name
+   DATA nPort       INIT 0         // Port number
+   DATA cDatabase   INIT ""        // Database name or file path
+   DATA cUser       INIT ""        // Username
+   DATA cPassword   INIT ""        // Password
+   DATA cCharSet    INIT "UTF8"    // Character set
+   DATA lConnected  INIT .F.       // Connection status
+   DATA cLastError  INIT ""        // Last error message
+   DATA pHandle     INIT nil       // Native connection handle
+   DATA cDriver     INIT ""        // Driver name (for identification)
+
+   METHOD New() CONSTRUCTOR
+   METHOD Open()
+   METHOD Close()
+   METHOD Execute( cSQL )
+   METHOD Query( cSQL )
+   METHOD TableExists( cTable )
+   METHOD Tables()
+   METHOD LastError()
+   METHOD IsConnected()
+
+ENDCLASS
+
+METHOD New() CLASS TDatabase
+return Self
+
+METHOD Open() CLASS TDatabase
+   ::cLastError := "Abstract: override Open() in subclass"
+return .F.
+
+METHOD Close() CLASS TDatabase
+   ::lConnected := .F.
+   ::pHandle := nil
+return nil
+
+METHOD Execute( cSQL ) CLASS TDatabase
+   HB_SYMBOL_UNUSED( cSQL )
+   ::cLastError := "Abstract: override Execute() in subclass"
+return .F.
+
+METHOD Query( cSQL ) CLASS TDatabase
+   HB_SYMBOL_UNUSED( cSQL )
+   ::cLastError := "Abstract: override Query() in subclass"
+return {}
+
+METHOD TableExists( cTable ) CLASS TDatabase
+   HB_SYMBOL_UNUSED( cTable )
+return .F.
+
+METHOD Tables() CLASS TDatabase
+return {}
+
+METHOD LastError() CLASS TDatabase
+return ::cLastError
+
+METHOD IsConnected() CLASS TDatabase
+return ::lConnected
+
+//----------------------------------------------------------------------------//
+// TODBCDatabase - generic ODBC connection via hbodbc low-level SQL*
+//----------------------------------------------------------------------------//
+CLASS TODBCDatabase INHERIT TDatabase
+
+   DATA cConnString INIT ""
+   DATA pHEnv       INIT nil
+   DATA pHDbc       INIT nil
+   DATA cTable      INIT ""
+   DATA cSQL        INIT ""
+   DATA aRows       INIT {}
+   DATA aFieldNames INIT {}
+   DATA nRecord     INIT 0
+   DATA bOnConnect    INIT nil
+   DATA bOnDisconnect INIT nil
+   DATA bOnError      INIT nil
+
+   METHOD New() CONSTRUCTOR
+   METHOD BuildConnString()
+   METHOD Open()
+   METHOD Close()
+   METHOD Execute( cSQL )
+   METHOD Query( cSQL )
+   METHOD TableExists( cTable )
+   METHOD Tables()
+   METHOD LoadCursor()
+   METHOD FieldCount()
+   METHOD FieldName( n )
+   METHOD GoTop()
+   METHOD Eof()
+   METHOD FieldGet( n )
+   METHOD Skip( n )
+   METHOD FireError( cMsg )
+   METHOD LastDiag()
+
+ENDCLASS
+
+METHOD New() CLASS TODBCDatabase
+   ::cDriver := "ODBC"
+   return Self
+
+METHOD FireError( cMsg ) CLASS TODBCDatabase
+   ::cLastError := cMsg
+   if ::bOnError != nil
+      Eval( ::bOnError, cMsg )
+   endif
+   return Self
+
+METHOD LastDiag() CLASS TODBCDatabase
+   local cState := Space( 16 ), nNative := 0, cText := Space( 512 )
+   SQLError( ::pHEnv, ::pHDbc, nil, @cState, @nNative, @cText )
+   return AllTrim( cState ) + ": " + AllTrim( cText )
+
+METHOD BuildConnString() CLASS TODBCDatabase
+   // Task 2 fills the per-dialect templates; base returns cConnString as-is.
+   return ::cConnString
+
+METHOD Open() CLASS TODBCDatabase
+   local hEnv := nil, hDbc := nil, nRet, cOut := Space( 1024 )
+   if SQLAllocEnv( @hEnv ) != SQL_SUCCESS
+      ::FireError( "ODBC: cannot allocate environment" ); return .F.
+   endif
+   if SQLAllocConnect( hEnv, @hDbc ) != SQL_SUCCESS
+      ::FireError( "ODBC: cannot allocate connection" ); SQLFreeEnv( hEnv ); return .F.
+   endif
+   nRet := SQLDriverConnect( hDbc, ::BuildConnString(), @cOut, SQL_DRIVER_NOPROMPT )
+   if nRet != SQL_SUCCESS .and. nRet != SQL_SUCCESS_WITH_INFO
+      ::pHEnv := hEnv ; ::pHDbc := hDbc
+      ::FireError( "ODBC connect failed: " + ::LastDiag() )
+      SQLDisconnect( hDbc ) ; SQLFreeConnect( hDbc ) ; SQLFreeEnv( hEnv )
+      ::pHEnv := nil ; ::pHDbc := nil
+      return .F.
+   endif
+   ::pHEnv := hEnv
+   ::pHDbc := hDbc
+   ::lConnected := .T.
+   if ::bOnConnect != nil ; Eval( ::bOnConnect ) ; endif
+   return .T.
+
+METHOD Close() CLASS TODBCDatabase
+   if ::pHDbc != nil
+      SQLDisconnect( ::pHDbc )
+      SQLFreeConnect( ::pHDbc )
+   endif
+   if ::pHEnv != nil
+      SQLFreeEnv( ::pHEnv )
+   endif
+   ::pHDbc := nil ; ::pHEnv := nil
+   ::lConnected := .F.
+   if ::bOnDisconnect != nil ; Eval( ::bOnDisconnect ) ; endif
+   return nil
+
+// Each operation uses its OWN fresh statement handle (allocated + dropped here).
+// A shared/reused handle hits a dBase/Jet quirk where a SELECT re-executed on a
+// handle that previously ran a SELECT returns no rows even after SQL_CLOSE.
+METHOD Execute( cSQL ) CLASS TODBCDatabase
+   local hStmt := nil, nRet
+   if ! ::lConnected ; ::FireError( "Not connected" ) ; return .F. ; endif
+   if SQLAllocStmt( ::pHDbc, @hStmt ) != SQL_SUCCESS
+      ::FireError( "ODBC: cannot allocate statement" ) ; return .F.
+   endif
+   nRet := SQLExecDirect( hStmt, cSQL )
+   if nRet != SQL_SUCCESS .and. nRet != SQL_SUCCESS_WITH_INFO
+      ::FireError( "ODBC exec failed: " + ::LastDiag() )
+      SQLFreeStmt( hStmt, SQL_FREESTMT_DROP )
+      return .F.
+   endif
+   SQLFreeStmt( hStmt, SQL_FREESTMT_DROP )
+   return .T.
+
+METHOD Query( cSQL ) CLASS TODBCDatabase
+   local hStmt := nil, nRet, nCols := 0, i, aRow, xVal
+   local cName, nNameLen, nType, nColSize, nDec, nNull
+   local aTypes := {}
+   ::aRows := {} ; ::aFieldNames := {} ; ::nRecord := 0
+   if ! ::lConnected ; ::FireError( "Not connected" ) ; return {} ; endif
+   if ! Empty( cSQL ) ; ::cSQL := cSQL ; endif
+   if SQLAllocStmt( ::pHDbc, @hStmt ) != SQL_SUCCESS
+      ::FireError( "ODBC: cannot allocate statement" ) ; return {}
+   endif
+   nRet := SQLExecDirect( hStmt, ::cSQL )
+   if nRet != SQL_SUCCESS .and. nRet != SQL_SUCCESS_WITH_INFO
+      ::FireError( "ODBC query failed: " + ::LastDiag() )
+      SQLFreeStmt( hStmt, SQL_FREESTMT_DROP ) ; return {}
+   endif
+   SQLNumResultCols( hStmt, @nCols )
+   for i := 1 to nCols
+      cName := Space( 256 ) ; nNameLen := 0 ; nType := 0
+      nColSize := 0 ; nDec := 0 ; nNull := 0
+      SQLDescribeCol( hStmt, i, @cName, 256, @nNameLen, @nType, @nColSize, @nDec, @nNull )
+      AAdd( ::aFieldNames, AllTrim( cName ) )
+      AAdd( aTypes, nType )
+   next
+   do while ( nRet := SQLFetch( hStmt ) ) == SQL_SUCCESS .or. nRet == SQL_SUCCESS_WITH_INFO
+      aRow := {}
+      for i := 1 to nCols
+         if _OdbcIsNumeric( aTypes[ i ] )
+            xVal := nil
+            SQLGetData( hStmt, i, SQL_C_DOUBLE, 0, @xVal )
+         else
+            xVal := Space( 4096 )
+            SQLGetData( hStmt, i, SQL_C_CHAR, 4096, @xVal )
+            xVal := RTrim( xVal )
+         endif
+         AAdd( aRow, xVal )
+      next
+      AAdd( ::aRows, aRow )
+   enddo
+   SQLFreeStmt( hStmt, SQL_FREESTMT_DROP )
+   ::nRecord := iif( Len( ::aRows ) > 0, 1, 0 )
+   return ::aRows
+
+METHOD LoadCursor() CLASS TODBCDatabase
+   local cQuery := iif( ! Empty( ::cSQL ), ::cSQL, ;
+                  iif( ! Empty( ::cTable ), "SELECT * FROM " + ::cTable, "" ) )
+   if Empty( cQuery ) ; return Self ; endif
+   ::Query( cQuery )
+   return Self
+
+METHOD FieldCount() CLASS TODBCDatabase
+   return Len( ::aFieldNames )
+
+METHOD FieldName( n ) CLASS TODBCDatabase
+   return iif( n >= 1 .and. n <= Len( ::aFieldNames ), ::aFieldNames[ n ], "" )
+
+METHOD GoTop() CLASS TODBCDatabase
+   ::nRecord := iif( Len( ::aRows ) > 0, 1, 0 )
+   return Self
+
+METHOD Eof() CLASS TODBCDatabase
+   return ::nRecord == 0 .or. ::nRecord > Len( ::aRows )
+
+METHOD FieldGet( n ) CLASS TODBCDatabase
+   if ! ::Eof() .and. n >= 1 .and. n <= Len( ::aRows[ ::nRecord ] )
+      return ::aRows[ ::nRecord ][ n ]
+   endif
+   return nil
+
+METHOD Skip( n ) CLASS TODBCDatabase
+   hb_default( @n, 1 )
+   ::nRecord += n
+   if ::nRecord < 1 ; ::nRecord := 1 ; endif
+   return Self
+
+METHOD TableExists( cTable ) CLASS TODBCDatabase
+   // Probe with a zero-row SELECT on a fresh statement (this hbodbc build does
+   // not export SQLTables). Does not touch ::aRows / ::cLastError.
+   local hStmt := nil, nRet, lOk
+   if ! ::lConnected ; return .F. ; endif
+   if SQLAllocStmt( ::pHDbc, @hStmt ) != SQL_SUCCESS ; return .F. ; endif
+   nRet := SQLExecDirect( hStmt, "SELECT * FROM " + cTable + " WHERE 1 = 0" )
+   lOk  := ( nRet == SQL_SUCCESS .or. nRet == SQL_SUCCESS_WITH_INFO )
+   SQLFreeStmt( hStmt, SQL_FREESTMT_DROP )
+   return lOk
+
+METHOD Tables() CLASS TODBCDatabase
+   // Generic table enumeration needs the ODBC catalog API (SQLTables), which is
+   // NOT exported by this hbodbc build -> returns empty. Callers that need a
+   // table list should use a dialect-specific catalog query via Query().
+   return {}
+
+// Numeric SQL type codes (ANSI): NUMERIC 2, DECIMAL 3, INTEGER 4, SMALLINT 5,
+// FLOAT 6, REAL 7, DOUBLE 8, BIGINT -5, TINYINT -6, BIT -7.
+STATIC FUNCTION _OdbcIsNumeric( nType )
+   return nType == 2 .or. nType == 3 .or. nType == 4 .or. nType == 5 .or. ;
+          nType == 6 .or. nType == 7 .or. nType == 8 .or. ;
+          nType == -5 .or. nType == -6 .or. nType == -7

--- a/source/core/db_odbc.prg
+++ b/source/core/db_odbc.prg
@@ -135,8 +135,32 @@ METHOD LastDiag() CLASS TODBCDatabase
    return AllTrim( cState ) + ": " + AllTrim( cText )
 
 METHOD BuildConnString() CLASS TODBCDatabase
-   // Task 2 fills the per-dialect templates; base returns cConnString as-is.
-   return ::cConnString
+   // An explicit cConnString always wins; otherwise template per dialect from
+   // the connection DATA. Subclasses set ::cDriver so the do-case picks a shape.
+   local cD, c
+   if ! Empty( ::cConnString )
+      return ::cConnString
+   endif
+   cD := Upper( ::cDriver )
+   do case
+   case "FIREBIRD" $ cD .or. "INTERBASE" $ cD
+      c := "Driver={" + ::cDriver + "};" + ;
+           "Dbname=" + ::cServer + "/" + LTrim( Str( ::nPort ) ) + ":" + ::cDatabase + ";" + ;
+           "Uid=" + ::cUser + ";Pwd=" + ::cPassword + ";"
+   case "SQL SERVER" $ cD
+      c := "Driver={" + ::cDriver + "};" + ;
+           "Server=" + ::cServer + "," + LTrim( Str( ::nPort ) ) + ";" + ;
+           "Database=" + ::cDatabase + ";" + ;
+           "Uid=" + ::cUser + ";Pwd=" + ::cPassword + ";TrustServerCertificate=yes;"
+   case "ORACLE" $ cD
+      c := "Driver={" + ::cDriver + "};" + ;
+           "Dbq=" + ::cServer + ":" + LTrim( Str( ::nPort ) ) + "/" + ::cDatabase + ";" + ;
+           "Uid=" + ::cUser + ";Pwd=" + ::cPassword + ";"
+   otherwise
+      c := "Driver={" + ::cDriver + "};DBQ=" + ::cDatabase + ";" + ;
+           "Uid=" + ::cUser + ";Pwd=" + ::cPassword + ";"
+   endcase
+   return c
 
 METHOD Open() CLASS TODBCDatabase
    local hEnv := nil, hDbc := nil, nRet, cOut := Space( 1024 )
@@ -288,3 +312,35 @@ STATIC FUNCTION _OdbcIsNumeric( nType )
    return nType == 2 .or. nType == 3 .or. nType == 4 .or. nType == 5 .or. ;
           nType == 6 .or. nType == 7 .or. nType == 8 .or. ;
           nType == -5 .or. nType == -6 .or. nType == -7
+
+//----------------------------------------------------------------------------//
+// TFirebird / TSQLServer / TOracle - friendly, IDE-facing names; the real
+// engine is TODBCDatabase. Each just sets the default ODBC driver name + port;
+// the user may override ::cDriver / ::cConnString to match a local install.
+//----------------------------------------------------------------------------//
+CLASS TFirebird INHERIT TODBCDatabase
+   METHOD New() CONSTRUCTOR
+ENDCLASS
+METHOD New() CLASS TFirebird
+   ::Super:New()
+   ::cDriver := "Firebird/InterBase(r) driver"
+   ::nPort   := 3050
+   return Self
+
+CLASS TSQLServer INHERIT TODBCDatabase
+   METHOD New() CONSTRUCTOR
+ENDCLASS
+METHOD New() CLASS TSQLServer
+   ::Super:New()
+   ::cDriver := "ODBC Driver 18 for SQL Server"
+   ::nPort   := 1433
+   return Self
+
+CLASS TOracle INHERIT TODBCDatabase
+   METHOD New() CONSTRUCTOR
+ENDCLASS
+METHOD New() CLASS TOracle
+   ::Super:New()
+   ::cDriver := "Microsoft ODBC for Oracle"
+   ::nPort   := 1521
+   return Self

--- a/source/hbbuilder_linux.prg
+++ b/source/hbbuilder_linux.prg
@@ -2884,6 +2884,7 @@ static function TBRun()
       cLog += "    " + aModules[i][1] + ".prg (module)" + Chr(10)
    next
    GTK_ShellExec( "cp " + cProjDir + "/source/core/classes.prg " + cBuildDir + "/" )
+   GTK_ShellExec( "cp " + cProjDir + "/source/core/db_odbc.prg " + cBuildDir + "/" )
    GTK_ShellExec( "cp " + cProjDir + "/include/hbbuilder.ch " + cBuildDir + "/" )
    GTK_ShellExec( "cp " + cProjDir + "/include/hbide.ch " + cBuildDir + "/" )
 
@@ -2989,6 +2990,7 @@ static function TBRun()
               " -lrddntx -lrddnsx -lrddcdx -lrddfpt" + ;
               " -lhbhsx -lhbsix -lhbusrrdd" + ;
               " -lhbsqlit3 -lsddsqlt3 -lrddsql" + ;
+              " -lhbodbc -lodbc" + ;
               " -lgttrm -lhbpcre" + ;
               " $(for d in /usr/lib /usr/lib64 /lib /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu; do ls $d/libgpm.so* >/dev/null 2>&1 && { echo -lgpm; break; }; done)" + ;
               " -Wl,--end-group" + ;
@@ -3082,6 +3084,7 @@ static function TBDebugRun( lRunToBreak )
          CodeEditorGetTabText( hCodeEditor, i + 1 ) )
    next
    GTK_ShellExec( "cp " + cProjDir + "/source/core/classes.prg " + cBuildDir + "/" )
+   GTK_ShellExec( "cp " + cProjDir + "/source/core/db_odbc.prg " + cBuildDir + "/" )
    GTK_ShellExec( "cp " + cProjDir + "/include/hbbuilder.ch " + cBuildDir + "/" )
    GTK_ShellExec( "cp " + cProjDir + "/include/hbide.ch " + cBuildDir + "/" )
    GTK_ShellExec( "cp " + cProjDir + "/source/debugger/dbgclient.prg " + cBuildDir + "/" )
@@ -3196,6 +3199,7 @@ static function TBDebugRun( lRunToBreak )
               " -lrddntx -lrddnsx -lrddcdx -lrddfpt" + ;
               " -lhbhsx -lhbsix -lhbusrrdd" + ;
               " -lhbsqlit3 -lsddsqlt3 -lrddsql" + ;
+              " -lhbodbc -lodbc" + ;
               " -lgttrm -lhbpcre" + ;
               " $(for d in /usr/lib /usr/lib64 /lib /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu; do ls $d/libgpm.so* >/dev/null 2>&1 && { echo -lgpm; break; }; done)" + ;
               " -Wl,--end-group" + ;

--- a/source/hbbuilder_linux.prg
+++ b/source/hbbuilder_linux.prg
@@ -2890,16 +2890,17 @@ static function TBRun()
    // Step 2: Assemble main.prg
    GTK_ProgressStep( "Assembling main.prg..." )
    cLog += "[2] Building main.prg..." + Chr(10)
+   // classes.prg is compiled as its OWN object (step 4) and linked separately.
+   // Strip BOTH #includes from EVERY piece (Project1, forms, modules) so the
+   // framework is never compiled into main.c too — duplicate inclusion is what
+   // caused "multiple definition of HB_FUN_TCONTROL" on Linux (issues #16/#13).
    cAllPrg := '#include "hbbuilder.ch"' + Chr(10) + Chr(10)
-   cAllPrg += StrTran( MemoRead( cBuildDir + "/Project1.prg" ), ;
-                       '#include "hbbuilder.ch"', "" ) + Chr(10)
+   cAllPrg += _StripFwkIncludes( MemoRead( cBuildDir + "/Project1.prg" ) ) + Chr(10)
    for i := 1 to Len( aForms )
-      cAllPrg += MemoRead( cBuildDir + "/" + aForms[i][1] + ".prg" ) + Chr(10)
+      cAllPrg += _StripFwkIncludes( MemoRead( cBuildDir + "/" + aForms[i][1] + ".prg" ) ) + Chr(10)
    next
    for i := 1 to Len( aModules )
-      cAllPrg += StrTran( StrTran( MemoRead( cBuildDir + "/" + aModules[i][1] + ".prg" ), ;
-                          '#include "classes.prg"', "" ), ;
-                          '#include "hbbuilder.ch"', "" ) + Chr(10)
+      cAllPrg += _StripFwkIncludes( MemoRead( cBuildDir + "/" + aModules[i][1] + ".prg" ) ) + Chr(10)
    next
    MemoWrit( cBuildDir + "/main.prg", cAllPrg )
    MemoWrit( "/tmp/hbbuilder_debug_main.prg", cAllPrg )
@@ -2989,6 +2990,7 @@ static function TBRun()
               " -lhbhsx -lhbsix -lhbusrrdd" + ;
               " -lhbsqlit3 -lsddsqlt3 -lrddsql" + ;
               " -lgttrm -lhbpcre" + ;
+              " $(for d in /usr/lib /usr/lib64 /lib /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu; do ls $d/libgpm.so* >/dev/null 2>&1 && { echo -lgpm; break; }; done)" + ;
               " -Wl,--end-group" + ;
               " $(pkg-config --libs gtk+-3.0)" + ;
               " $(pkg-config --exists webkit2gtk-4.1 2>/dev/null && pkg-config --libs webkit2gtk-4.1 || " + ;
@@ -3195,6 +3197,7 @@ static function TBDebugRun( lRunToBreak )
               " -lhbhsx -lhbsix -lhbusrrdd" + ;
               " -lhbsqlit3 -lsddsqlt3 -lrddsql" + ;
               " -lgttrm -lhbpcre" + ;
+              " $(for d in /usr/lib /usr/lib64 /lib /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu; do ls $d/libgpm.so* >/dev/null 2>&1 && { echo -lgpm; break; }; done)" + ;
               " -Wl,--end-group" + ;
               " $(pkg-config --libs gtk+-3.0)" + ;
               " " + cWebKitLibs + ;
@@ -4203,6 +4206,21 @@ static function ComponentTypeFromName( cName )
       case cName == "CT_POPUPMENU";     return 136
    endcase
 return 0
+
+// Strip framework #includes from a project source piece before it is
+// concatenated into main.prg. classes.prg is compiled as its own object and
+// linked separately, so leaving the #include in would compile the framework
+// twice -> "multiple definition of HB_FUN_*" at link time (issues #16/#13).
+// hbbuilder.ch is prepended once at the top of main.prg, so strip it too.
+static function _StripFwkIncludes( cSrc )
+   if cSrc == nil
+      return ""
+   endif
+   cSrc := StrTran( cSrc, '#include "classes.prg"', "" )
+   cSrc := StrTran( cSrc, "#include 'classes.prg'", "" )
+   cSrc := StrTran( cSrc, '#include "hbbuilder.ch"', "" )
+   cSrc := StrTran( cSrc, "#include 'hbbuilder.ch'", "" )
+return cSrc
 
 // Framework
 #include "core/classes.prg"

--- a/source/hbbuilder_macos.prg
+++ b/source/hbbuilder_macos.prg
@@ -4139,22 +4139,22 @@ static function TBRun()
    // Step 2: Assemble main.prg
    MAC_ProgressStep( 2, "Assembling main.prg..." )
    cLog += "[2] Building main.prg..." + Chr(10)
+   // classes.prg is compiled as its OWN object (step 4) and linked separately.
+   // Strip BOTH #includes (single- AND double-quoted) from EVERY piece so the
+   // framework is never compiled into main.c too — duplicate inclusion is what
+   // caused "multiple definition of HB_FUN_*" (issues #16/#13). The old inline
+   // StrTran only caught double-quoted includes, letting AI-generated forms
+   // (which emit single-quoted '#include' lines) slip the framework in twice.
    cAllPrg := '#include "hbbuilder.ch"' + Chr(10)
    cAllPrg += "REQUEST HB_GT_NUL_DEFAULT" + Chr(10)
    cAllPrg += "REQUEST DBFCDX, DBFNTX, DBFFPT" + Chr(10) + Chr(10)
-   cAllPrg += StrTran( StrTran( StrTran( MemoRead( cBuildDir + "/Project1.prg" ), ;
-                       '#include "hbbuilder.ch"', "" ), ;
-                       '#include "classes.prg"', "" ), ;
+   cAllPrg += StrTran( _StripFwkIncludes( MemoRead( cBuildDir + "/Project1.prg" ) ), ;
                        "REQUEST HB_GT_GUI_DEFAULT", "" ) + Chr(10)
    for i := 1 to Len( aForms )
-      cAllPrg += StrTran( StrTran( MemoRead( cBuildDir + "/" + aForms[i][1] + ".prg" ), ;
-                          '#include "classes.prg"', "" ), ;
-                          '#include "hbbuilder.ch"', "" ) + Chr(10)
+      cAllPrg += _StripFwkIncludes( MemoRead( cBuildDir + "/" + aForms[i][1] + ".prg" ) ) + Chr(10)
    next
    for i := 1 to Len( aModules )
-      cAllPrg += StrTran( StrTran( MemoRead( cBuildDir + "/" + aModules[i][1] + ".prg" ), ;
-                          '#include "classes.prg"', "" ), ;
-                          '#include "hbbuilder.ch"', "" ) + Chr(10)
+      cAllPrg += _StripFwkIncludes( MemoRead( cBuildDir + "/" + aModules[i][1] + ".prg" ) ) + Chr(10)
    next
    MemoWrit( cBuildDir + "/main.prg", cAllPrg )
 
@@ -6460,6 +6460,22 @@ static function GitBlameShow()
    cOut := GIT_Exec( "blame " + hb_FNameNameExt( cFile ), hb_FNameDir( cFile ) )
    MsgInfo( iif( Empty(cOut), "No blame data", Left(cOut, 3000) ), "Git Blame" )
 return nil
+
+// Strip framework #includes from a project source piece before it is
+// concatenated into main.prg. classes.prg is compiled as its own object and
+// linked separately, so leaving the #include in would compile the framework
+// twice -> "multiple definition of HB_FUN_*" at link time (issues #16/#13).
+// hbbuilder.ch is prepended once at the top of main.prg, so strip it too.
+// Both quote styles are handled (AI-generated forms emit single-quoted includes).
+static function _StripFwkIncludes( cSrc )
+   if cSrc == nil
+      return ""
+   endif
+   cSrc := StrTran( cSrc, '#include "classes.prg"', "" )
+   cSrc := StrTran( cSrc, "#include 'classes.prg'", "" )
+   cSrc := StrTran( cSrc, '#include "hbbuilder.ch"', "" )
+   cSrc := StrTran( cSrc, "#include 'hbbuilder.ch'", "" )
+return cSrc
 
 // Framework
 #include "classes.prg"

--- a/source/hbbuilder_macos.prg
+++ b/source/hbbuilder_macos.prg
@@ -4122,6 +4122,7 @@ static function TBRun()
    // Copy framework files (bundle Resources/ or source tree harbour/)
    if File( HB_DirBase() + "../Resources/classes.prg" )
       MAC_ShellExec( "cp " + HB_DirBase() + "../Resources/classes.prg " + cBuildDir + "/" )
+      MAC_ShellExec( "cp " + HB_DirBase() + "../Resources/db_odbc.prg " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + HB_DirBase() + "../Resources/hbbuilder.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + HB_DirBase() + "../Resources/hbide.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + HB_DirBase() + "../Resources/stddlgs_mac.mm " + cBuildDir + "/ 2>/dev/null" )
@@ -4129,6 +4130,7 @@ static function TBRun()
       MAC_ShellExec( "cp " + HB_DirBase() + "../Resources/hix_template.prg " + cBuildDir + "/ 2>/dev/null" )
    else
       MAC_ShellExec( "cp " + cProjDir + "/source/core/classes.prg " + cBuildDir + "/" )
+      MAC_ShellExec( "cp " + cProjDir + "/source/core/db_odbc.prg " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cProjDir + "/include/hbbuilder.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cProjDir + "/include/hbide.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cProjDir + "/resources/stddlgs_mac.mm " + cBuildDir + "/ 2>/dev/null" )
@@ -4347,6 +4349,7 @@ static function TBRun()
               " -lhbvm -lhbrtl -lhbcommon -lhbcpage -lhblang" + ;
               " -lhbmacro -lhbpp -lhbrdd -lhbcplr -lhbdebug" + ;
               " -lhbct -lhbextern -lhbsqlit3" + ;
+              " -lhbodbc -liodbc" + ;
               " -lrddntx -lrddnsx -lrddcdx -lrddfpt" + ;
               " -lhbhsx -lhbsix -lhbusrrdd" + ;
               " -lgtcgi -lgtstd" + ;
@@ -4494,6 +4497,7 @@ static function TBDebugRun( lRunToBreakpoint )
    next
    if File( cResDir + "/classes.prg" )
       MAC_ShellExec( "cp " + cResDir + "/classes.prg " + cBuildDir + "/" )
+      MAC_ShellExec( "cp " + cResDir + "/db_odbc.prg " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cResDir + "/hbbuilder.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cResDir + "/hbide.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cResDir + "/dbgclient.prg " + cBuildDir + "/" )
@@ -4502,6 +4506,7 @@ static function TBDebugRun( lRunToBreakpoint )
       MAC_ShellExec( "cp " + cResDir + "/hix_template.prg " + cBuildDir + "/ 2>/dev/null" )
    else
       MAC_ShellExec( "cp " + cProjDir + "/source/core/classes.prg " + cBuildDir + "/" )
+      MAC_ShellExec( "cp " + cProjDir + "/source/core/db_odbc.prg " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cProjDir + "/include/hbbuilder.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cProjDir + "/include/hbide.ch " + cBuildDir + "/" )
       MAC_ShellExec( "cp " + cProjDir + "/source/debugger/dbgclient.prg " + cBuildDir + "/" )
@@ -4651,6 +4656,7 @@ static function TBDebugRun( lRunToBreakpoint )
               " -lhbvm -lhbrtl -lhbcommon -lhbcpage -lhblang" + ;
               " -lhbmacro -lhbpp -lhbrdd -lhbcplr -lhbdebug" + ;
               " -lhbct -lhbextern -lhbsqlit3" + ;
+              " -lhbodbc -liodbc" + ;
               " -lrddntx -lrddnsx -lrddcdx -lrddfpt" + ;
               " -lhbhsx -lhbsix -lhbusrrdd" + ;
               " -lgtcgi -lgtstd" + ;

--- a/source/hbbuilder_win.prg
+++ b/source/hbbuilder_win.prg
@@ -5067,7 +5067,31 @@ static function ShowProjectOptions()
    static lDebugInfo    := .F.
    static lWarnings     := .T.
    static lOptimize     := .T.
-   local aCI
+   static lLoaded       := .F.
+   local aCI, hCfg
+
+   // Load persisted options once per session (issue #15: settings must
+   // survive a restart). Stored next to the IDE exe via hb_DirBase() so it
+   // is portable and avoids non-writable hardcoded paths.
+   if ! lLoaded
+      hCfg := LoadProjOptions()
+      if hCfg != nil
+         cHarbourDir   := hb_HGetDef( hCfg, "HarbourDir",   cHarbourDir   )
+         cCompilerDir  := hb_HGetDef( hCfg, "CompilerDir",  cCompilerDir  )
+         cProjectDir   := hb_HGetDef( hCfg, "ProjectDir",   cProjectDir   )
+         cOutputDir    := hb_HGetDef( hCfg, "OutputDir",    cOutputDir    )
+         cHbFlags      := hb_HGetDef( hCfg, "HbFlags",      cHbFlags      )
+         cCFlags       := hb_HGetDef( hCfg, "CFlags",       cCFlags       )
+         cLinkFlags    := hb_HGetDef( hCfg, "LinkFlags",    cLinkFlags    )
+         cIncludePaths := hb_HGetDef( hCfg, "IncludePaths", cIncludePaths )
+         cLibPaths     := hb_HGetDef( hCfg, "LibPaths",     cLibPaths     )
+         cLibraries    := hb_HGetDef( hCfg, "Libraries",    cLibraries    )
+         lDebugInfo    := hb_HGetDef( hCfg, "DebugInfo",    lDebugInfo    )
+         lWarnings     := hb_HGetDef( hCfg, "Warnings",     lWarnings     )
+         lOptimize     := hb_HGetDef( hCfg, "Optimize",     lOptimize     )
+      endif
+      lLoaded := .T.
+   endif
 
    // Auto-detect paths from current compiler on first open
    if Empty( cHarbourDir )
@@ -5086,13 +5110,48 @@ static function ShowProjectOptions()
       if Empty( cHarbourDir ); cHarbourDir := "c:\harbour"; endif
    endif
 
-   W32_ProjectOptionsDialog( ;
-      cHarbourDir, cCompilerDir, cProjectDir, cOutputDir, ;
-      cHbFlags, cCFlags, cLinkFlags, ;
-      cIncludePaths, cLibPaths, cLibraries, ;
-      lDebugInfo, lWarnings, lOptimize )
+   // Pass by reference so the dialog can hand edited values back; it returns
+   // .T. only when the user clicked OK (Save). Then persist (issue #15).
+   if W32_ProjectOptionsDialog( ;
+         @cHarbourDir, @cCompilerDir, @cProjectDir, @cOutputDir, ;
+         @cHbFlags, @cCFlags, @cLinkFlags, ;
+         @cIncludePaths, @cLibPaths, @cLibraries, ;
+         @lDebugInfo, @lWarnings, @lOptimize )
+
+      if ! SaveProjOptions( { ;
+            "HarbourDir"   => cHarbourDir,   "CompilerDir"  => cCompilerDir, ;
+            "ProjectDir"   => cProjectDir,   "OutputDir"    => cOutputDir, ;
+            "HbFlags"      => cHbFlags,      "CFlags"       => cCFlags, ;
+            "LinkFlags"    => cLinkFlags,    "IncludePaths" => cIncludePaths, ;
+            "LibPaths"     => cLibPaths,     "Libraries"    => cLibraries, ;
+            "DebugInfo"    => lDebugInfo,    "Warnings"     => lWarnings, ;
+            "Optimize"     => lOptimize } )
+         MsgInfo( "Could not save project options to:" + Chr(13) + Chr(10) + ProjOptCfgPath() )
+      endif
+   endif
 
 return nil
+
+// --- Project Options persistence (issue #15) ----------------------------
+// Stored as JSON next to the IDE executable (portable; no hardcoded path).
+
+static function ProjOptCfgPath()
+return hb_DirBase() + "projoptions.json"
+
+static function SaveProjOptions( hVals )
+return hb_MemoWrit( ProjOptCfgPath(), hb_jsonEncode( hVals, .T. ) )
+
+static function LoadProjOptions()
+   local cPath := ProjOptCfgPath(), cJson, xRet
+   if ! File( cPath )
+      return nil
+   endif
+   cJson := hb_MemoRead( cPath )
+   if Empty( cJson )
+      return nil
+   endif
+   hb_jsonDecode( cJson, @xRet )
+return iif( HB_ISHASH( xRet ), xRet, nil )
 
 // === Debugger ===
 
@@ -9580,6 +9639,13 @@ static void PO_ShowTab( PROJOPTDATA * d, int nTab )
 static HBRUSH s_hPODlgBrush  = NULL;
 static HBRUSH s_hPOEditBrush = NULL;
 
+/* Project Options dialog result (issue #15: Save did nothing — IDOK was a
+   no-op identical to Cancel, and nothing was ever read back or persisted).
+   On OK we harvest the edits here, then the HB_FUNC returns them by-ref. */
+static char s_poBuf[10][4096];   /* params 1..10: HbDir,CDir,ProjDir,OutDir,HbFlags,CFlags,LinkFlags,IncPaths,LibPaths,Libs */
+static BOOL s_poChk[3];          /* params 11..13: Debug, Warnings, Optimize */
+static BOOL s_poOK = FALSE;      /* TRUE only when the user clicked OK (Save) */
+
 static LRESULT CALLBACK ProjOptProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
 {
    PROJOPTDATA * d = (PROJOPTDATA*) GetWindowLongPtr(hWnd, GWLP_USERDATA);
@@ -9618,7 +9684,28 @@ static LRESULT CALLBACK ProjOptProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM 
          break;
       }
       case WM_COMMAND:
-         if(LOWORD(wParam)==IDOK || LOWORD(wParam)==IDCANCEL) {
+         if(LOWORD(wParam)==IDOK) {
+            if(d) {  /* harvest edits so they can be saved (issue #15) */
+               GetWindowTextA(d->hHbDir,    s_poBuf[0], sizeof(s_poBuf[0]));
+               GetWindowTextA(d->hCDir,     s_poBuf[1], sizeof(s_poBuf[1]));
+               GetWindowTextA(d->hProjDir,  s_poBuf[2], sizeof(s_poBuf[2]));
+               GetWindowTextA(d->hOutDir,   s_poBuf[3], sizeof(s_poBuf[3]));
+               GetWindowTextA(d->hHbFlags,  s_poBuf[4], sizeof(s_poBuf[4]));
+               GetWindowTextA(d->hCFlags,   s_poBuf[5], sizeof(s_poBuf[5]));
+               GetWindowTextA(d->hLinkFlags,s_poBuf[6], sizeof(s_poBuf[6]));
+               GetWindowTextA(d->hIncPaths, s_poBuf[7], sizeof(s_poBuf[7]));
+               GetWindowTextA(d->hLibPaths, s_poBuf[8], sizeof(s_poBuf[8]));
+               GetWindowTextA(d->hLibs,     s_poBuf[9], sizeof(s_poBuf[9]));
+               s_poChk[0] = (BOOL)(SendMessage(d->hChkDebug,BM_GETCHECK,0,0)==BST_CHECKED);
+               s_poChk[1] = (BOOL)(SendMessage(d->hChkWarn, BM_GETCHECK,0,0)==BST_CHECKED);
+               s_poChk[2] = (BOOL)(SendMessage(d->hChkOpt,  BM_GETCHECK,0,0)==BST_CHECKED);
+               s_poOK = TRUE;
+            }
+            EnableWindow(GetParent(hWnd)?GetParent(hWnd):GetDesktopWindow(),TRUE);
+            DestroyWindow(hWnd);
+            return 0;
+         }
+         if(LOWORD(wParam)==IDCANCEL) {
             EnableWindow(GetParent(hWnd)?GetParent(hWnd):GetDesktopWindow(),TRUE);
             DestroyWindow(hWnd);
             return 0;
@@ -9644,6 +9731,8 @@ HB_FUNC( W32_PROJECTOPTIONSDIALOG )
    HFONT hFont;
    MSG msg;
    int baseY = PO_TAB_HEIGHT + 48;
+
+   s_poOK = FALSE;   /* reset: stays FALSE if user cancels / closes (issue #15) */
 
    if(!bReg) {
       wc.lpfnWndProc=ProjOptProc; wc.hInstance=GetModuleHandle(NULL);
@@ -9732,6 +9821,18 @@ HB_FUNC( W32_PROJECTOPTIONSDIALOG )
          SendMessage(d.hDlg,WM_CLOSE,0,0); break; }
       TranslateMessage(&msg); DispatchMessage(&msg);
    }
+
+   /* Hand the edited values back to ShowProjectOptions() via by-ref params,
+      and return .T. only when the user clicked OK so the caller knows to
+      persist them. Before this fix the dialog returned nothing (issue #15). */
+   if( s_poOK ) {
+      hb_storc(s_poBuf[0],  1); hb_storc(s_poBuf[1],  2); hb_storc(s_poBuf[2], 3);
+      hb_storc(s_poBuf[3],  4); hb_storc(s_poBuf[4],  5); hb_storc(s_poBuf[5], 6);
+      hb_storc(s_poBuf[6],  7); hb_storc(s_poBuf[7],  8); hb_storc(s_poBuf[8], 9);
+      hb_storc(s_poBuf[9], 10);
+      hb_storl(s_poChk[0], 11); hb_storl(s_poChk[1], 12); hb_storl(s_poChk[2], 13);
+   }
+   hb_retl( s_poOK );
 }
 
 /* ======================================================================

--- a/source/hbbuilder_win.prg
+++ b/source/hbbuilder_win.prg
@@ -4035,6 +4035,7 @@ static function TBRun()
       cLog += "    " + aForms[i][1] + ".prg" + Chr(10)
    next
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\source\core\classes.prg" "' + cBuildDir + '\" >nul 2>&1' )
+   W32_ShellExec( 'cmd /c copy "' + cProjDir + '\source\core\db_odbc.prg" "' + cBuildDir + '\" >nul 2>&1' )
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\include\hbbuilder.ch" "' + cBuildDir + '\" >nul 2>&1' )
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\include\hbide.ch" "' + cBuildDir + '\" >nul 2>&1' )
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\resources\stddlgs.c" "' + cBuildDir + '\" >nul 2>&1' )
@@ -4385,6 +4386,7 @@ static function TBRun()
             cRspContent += "rddntx.lib rddnsx.lib rddcdx.lib rddfpt.lib" + Chr(10)
             cRspContent += "hbdebug.lib hbpcre.lib hbzlib.lib" + Chr(10)
             cRspContent += "hbsqlit3.lib sqlite3.lib" + Chr(10)
+            cRspContent += "hbodbc.lib odbc32.lib" + Chr(10)
             cRspContent += "gtwin.lib gtwvt.lib gtgui.lib" + Chr(10)
          endif
          cRspContent += "user32.lib gdi32.lib comctl32.lib comdlg32.lib shell32.lib" + Chr(10)
@@ -4408,6 +4410,7 @@ static function TBRun()
                     " -lrddntx -lrddnsx -lrddcdx -lrddfpt" + ;
                     " -lhbdebug -lhbpcre -lhbzlib" + ;
                     " -lhbsqlit3 -lsqlite3" + ;
+                    " -lhbodbc -lodbc32" + ;
                     " -lgtgui -lgtwin -lgtwvt" ) + ;
                  " -Wl,--end-group" + ;
                  " -luser32 -lgdi32 -lcomctl32 -lcomdlg32 -lshell32" + ;
@@ -4434,6 +4437,7 @@ static function TBRun()
                     " rddntx.lib rddnsx.lib rddcdx.lib rddfpt.lib" + ;
                     " hbdebug.lib hbpcre.lib hbzlib.lib" + ;
                     " hbsqlit3.lib sqlite3.lib" + ;
+                    " hbodbc.lib odbc32.lib" + ;
                     " gtwin.lib gtwvt.lib gtgui.lib" ) + ;
                  " cw32mt.lib import32.lib ws2_32.lib winmm.lib iphlpapi.lib" + ;
                  " user32.lib gdi32.lib comctl32.lib comdlg32.lib shell32.lib" + ;
@@ -5298,6 +5302,7 @@ static function TBDebugRun( lRunToBreak )
          CodeEditorGetTabText( hCodeEditor, i + 1 ) )
    next
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\source\core\classes.prg" "' + cBuildDir + '\" >nul 2>&1' )
+   W32_ShellExec( 'cmd /c copy "' + cProjDir + '\source\core\db_odbc.prg" "' + cBuildDir + '\" >nul 2>&1' )
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\include\hbbuilder.ch" "' + cBuildDir + '\" >nul 2>&1' )
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\include\hbide.ch" "' + cBuildDir + '\" >nul 2>&1' )
    W32_ShellExec( 'cmd /c copy "' + cProjDir + '\source\debugger\dbgclient.prg" "' + cBuildDir + '\" >nul 2>&1' )
@@ -5631,6 +5636,7 @@ static function TBDebugRun( lRunToBreak )
             cRspContent += "rddntx.lib rddnsx.lib rddcdx.lib rddfpt.lib" + Chr(10)
             cRspContent += "hbdebug.lib hbpcre.lib hbzlib.lib" + Chr(10)
             cRspContent += "hbsqlit3.lib sqlite3.lib" + Chr(10)
+            cRspContent += "hbodbc.lib odbc32.lib" + Chr(10)
             cRspContent += "gtwin.lib gtwvt.lib gtgui.lib" + Chr(10)
          endif
          cRspContent += "user32.lib gdi32.lib comctl32.lib comdlg32.lib shell32.lib" + Chr(10)
@@ -5654,6 +5660,7 @@ static function TBDebugRun( lRunToBreak )
                     " -lrddntx -lrddnsx -lrddcdx -lrddfpt" + ;
                     " -lhbdebug -lhbpcre -lhbzlib" + ;
                     " -lhbsqlit3 -lsqlite3" + ;
+                    " -lhbodbc -lodbc32" + ;
                     " -lgtgui -lgtwin -lgtwvt" ) + ;
                  " -Wl,--end-group" + ;
                  " -luser32 -lgdi32 -lcomctl32 -lcomdlg32 -lshell32" + ;
@@ -5680,6 +5687,7 @@ static function TBDebugRun( lRunToBreak )
                     " rddntx.lib rddnsx.lib rddcdx.lib rddfpt.lib" + ;
                     " hbdebug.lib hbpcre.lib hbzlib.lib" + ;
                     " hbsqlit3.lib sqlite3.lib" + ;
+                    " hbodbc.lib odbc32.lib" + ;
                     " gtwin.lib gtwvt.lib gtgui.lib" ) + ;
                  " cw32mt.lib import32.lib ws2_32.lib winmm.lib iphlpapi.lib" + ;
                  " user32.lib gdi32.lib comctl32.lib comdlg32.lib shell32.lib" + ;


### PR DESCRIPTION
## Summary

This PR adds a **universal ODBC database backend** that fills the previously stubbed Firebird / SQL Server / Oracle connections, and folds in a few build/IDE fixes for the open build issues.

### Database: `TODBCDatabase` (new ODBC backend)

`TFirebird`, `TSQLServer` and `TOracle` were stubs whose `Open()` just returned `.F.` with an "install X" message. They are now thin subclasses of a new generic **`TODBCDatabase`** built on Harbour's `hbodbc` contrib, so they actually connect — one ODBC code path covers all of them (and any DSN-less driver).

- New `source/core/db_odbc.prg` holds the abstract `TDatabase` base (moved out of `classes.prg`, defined once) plus `TODBCDatabase`. `classes.prg` `#include`s it early so every DB subclass inherits the base.
- `TODBCDatabase` returns an array-of-rows, matching the existing `TMySQL`/`TPostgreSQL` contract, so the IDE's data controls bind to it unchanged.
- `BuildConnString()` templates a DSN-less connection string per dialect (Firebird `Dbname`, SQL Server `Server,port`+`Database`, Oracle `Dbq`); an explicit `cConnString` always wins, and `cDriver` can be overridden to match a locally installed driver.
- The three build scripts now link `hbodbc` (+ `odbc32` on Windows, unixODBC on Linux, iODBC on macOS) and stage `db_odbc.prg` into the build dir next to `classes.prg`.

> The class is intentionally named `TODBCDatabase`, **not** `TODBC`, because `hbodbc` already exports a `TODBC` class (`HB_FUN_TODBC`) — reusing the name collides at link time (`LNK2005`).

`TMongoDB` is left as a stub (not SQL/ODBC; out of scope here).

### Build / IDE fixes

- **Linux build (#5, #11):** distro-portable library detection — pick `libncursesw.so`/`.so`/`.so.6` by what exists, and only add `-lgpm` when `libgpm` is present.
- **Multiple-definition `HB_FUN_*` (#13, #16):** the in-IDE builders now strip framework `#include`s (both quote styles) from every project piece before concatenation, so the framework is never compiled twice.
- **Project/Environment Options save (#15):** the dialog now harvests its fields and persists `projoptions.json` next to the executable (portable `hb_DirBase()` location), reloading on open.

## Testing

Verified on Windows (Harbour + MSVC, 32-bit):

- **Real ODBC round-trip** through `TODBCDatabase` against a file-based ODBC driver (zero server): `Open → CREATE → INSERT → SELECT → cursor walk (GoTop/Eof/FieldGet/Skip) → TableExists`, repeatable.
- **Full generated-app build through the IDE's own pipeline:** a minimal generated app that uses `TODBCDatabase`, compiled and linked exactly as the IDE does (`main.prg` + `classes.prg` compiled separately + the C++ core + the IDE's library list with `hbodbc`/`odbc32`). The resulting executable links cleanly and **connects + round-trips at runtime**.
- `harbour -n -w` parses `classes.prg` and all three builders cleanly.

### Notes / not yet verified

- Linux/macOS build-script changes are correct by inspection but were not built on those platforms.
- Firebird/SQL Server/Oracle were validated for connection-string shape and link wiring; a live-server round-trip for those engines hasn't been run yet.
- `hbodbc` in some builds does not export `SQLTables`, so `Tables()` returns `{}` and `TableExists()` probes with a zero-row `SELECT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
